### PR TITLE
Improvements in BinaryImageAsset/ImageAsset

### DIFF
--- a/Spectrum/src/com/unhurdle/spectrum/BinaryImageAsset.as
+++ b/Spectrum/src/com/unhurdle/spectrum/BinaryImageAsset.as
@@ -8,6 +8,13 @@ package com.unhurdle.spectrum
 
   public class BinaryImageAsset extends ImageAsset
   {
+    COMPILE::JS
+    private static function revokeObjURL(objectUrl:String):void{
+      if(objectUrl)
+        URLUtils.revokeObjectURL(objectUrl);
+    }
+    
+    
     public function BinaryImageAsset()
     {
       super();
@@ -29,11 +36,15 @@ package com.unhurdle.spectrum
         }
         COMPILE::JS
         {
-          if(_objectURL)
-            URLUtils.revokeObjectURL(_objectURL);
-          var blob:Blob = new Blob([value.array]);
-          _objectURL = URLUtils.createObjectURL(blob);
-          _imageElement.src = _objectURL;
+          revokeObjURL(_objectURL);
+          if (value) {
+            var blob:Blob = new Blob([value.array]);
+            _objectURL = URLUtils.createObjectURL(blob);
+            _imageElement.src = _objectURL;
+          } else {
+            _imageElement.src = "";
+          }
+          
           _src = "";
         }
       }
@@ -41,6 +52,10 @@ package com.unhurdle.spectrum
     override public function set src(value:String):void{
       super.src = value;
       _binary = null;
+      COMPILE::JS
+      {
+        revokeObjURL(_objectURL);
+      }
     }
 
   }

--- a/Spectrum/src/com/unhurdle/spectrum/BinaryImageAsset.as
+++ b/Spectrum/src/com/unhurdle/spectrum/BinaryImageAsset.as
@@ -9,9 +9,11 @@ package com.unhurdle.spectrum
   public class BinaryImageAsset extends ImageAsset
   {
     COMPILE::JS
-    private static function revokeObjURL(objectUrl:String):void{
-      if(objectUrl)
-        URLUtils.revokeObjectURL(objectUrl);
+    private static function revokeObjURL(inst:BinaryImageAsset):void{
+      if(inst._objectURL) {
+        URLUtils.revokeObjectURL(inst._objectURL);
+        inst._objectURL = null;
+      }
     }
     
     
@@ -36,7 +38,7 @@ package com.unhurdle.spectrum
         }
         COMPILE::JS
         {
-          revokeObjURL(_objectURL);
+          revokeObjURL(this);
           if (value) {
             var blob:Blob = new Blob([value.array]);
             _objectURL = URLUtils.createObjectURL(blob);
@@ -44,7 +46,6 @@ package com.unhurdle.spectrum
           } else {
             _imageElement.src = "";
           }
-          
           _src = "";
         }
       }
@@ -54,7 +55,7 @@ package com.unhurdle.spectrum
       _binary = null;
       COMPILE::JS
       {
-        revokeObjURL(_objectURL);
+        revokeObjURL(this);
       }
     }
 

--- a/Spectrum/src/com/unhurdle/spectrum/ImageAsset.as
+++ b/Spectrum/src/com/unhurdle/spectrum/ImageAsset.as
@@ -4,7 +4,7 @@ package com.unhurdle.spectrum
   import org.apache.royale.core.IValuesImpl;
   import org.apache.royale.events.Event;
 
-	[Event(name="error", type="org.apache.royale.events.Event")]
+  [Event(name="error", type="org.apache.royale.events.Event")]
   [Event(name="load", type="org.apache.royale.events.Event")]
   public class ImageAsset extends Asset
   {
@@ -31,6 +31,7 @@ package com.unhurdle.spectrum
         if(!_imageElement){
           createImageElement();
         }
+        if (value == null) value = ''; //null does not convert well
         _imageElement.src = value;
         _src = value;
       }


### PR DESCRIPTION
For BinaryImageAsset, a null assignment into the binary setter was not supported (RTE). And when setting src directly there was no revocation of any previous ObjectURL that may have been used. These changes make it easier to explicitly clear some memory by setting either value (binary or src) to null.